### PR TITLE
Upgrade to LiquiDEX v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,21 +9,21 @@ edition = "2018"
 crate-type = ["lib"]
 
 [dependencies]
-rand = "0.6.5"
+rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_cbor = "0.11.1"
 hex = "0.4.0"
 log = "0.4.8"
 aes-gcm-siv = "0.10.0"
-electrum-client = "0.10.0"
+electrum-client = "0.12.0"
 bip39 = "1.0.0-rc1"
-elements = { version = "0.19.2", features = ["serde-feature"] }
+elements = { version = "0.20.0", features = ["serde"] }
 
 [dev-dependencies]
 chrono = "0.4.11"
 tempdir = "0.3.7"
-electrsd = { version = "0.19.1", features = [ "legacy" ] }
+electrsd = { version = "0.21.1", features = [ "legacy" ] }
 
 [profile.release]
 lto = true

--- a/src/store.rs
+++ b/src/store.rs
@@ -26,7 +26,7 @@ pub type Store = Arc<RwLock<StoreMeta>>;
 
 /// RawCache is a persisted and encrypted cache of wallet data, contains stuff like wallet transactions
 /// It is fully reconstructable from xpub and data from electrum server (plus master blinding for elements)
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct RawCache {
     /// contains all my tx and all prevouts
     pub all_txs: HashMap<Txid, elements::Transaction>,
@@ -59,16 +59,25 @@ pub struct RawCache {
     pub indexes: Indexes,
 }
 
-/// RawStore contains data that are not extractable from xpub+blockchain
-#[derive(Default, Serialize, Deserialize)]
-pub struct RawStore {
-    /// Assets that might be received by a LiquiDEX maker
-    liquidex_assets: HashSet<elements::issuance::AssetId>,
+impl Default for RawCache {
+    fn default() -> Self {
+        Self {
+            all_txs: HashMap::default(),
+            paths: HashMap::default(),
+            scripts: HashMap::default(),
+            heights: HashMap::default(),
+            headers: HashMap::default(),
+            unblinded: HashMap::default(),
+            txs_verif: HashMap::default(),
+            fee_estimates: Vec::default(),
+            tip: (0, BlockHash::all_zeros()),
+            indexes: Indexes::default(),
+        }
+    }
 }
 
 pub struct StoreMeta {
     pub cache: RawCache,
-    pub store: RawStore,
     secp: Secp256k1<All>,
     path: PathBuf,
     cipher: Aes256GcmSiv,
@@ -105,23 +114,6 @@ impl RawCache {
 
     fn try_new<P: AsRef<Path>>(path: P, cipher: &Aes256GcmSiv) -> Result<Self, Error> {
         let decrypted = load_decrypt("cache", path, cipher)?;
-        let store = serde_cbor::from_slice(&decrypted)?;
-        Ok(store)
-    }
-}
-
-impl RawStore {
-    /// create a new RawStore, loading data from a file if any and if there is no error in reading
-    /// errors such as corrupted file or model change in the db, result in a empty store that will be repopulated
-    fn new<P: AsRef<Path>>(path: P, cipher: &Aes256GcmSiv) -> Self {
-        Self::try_new(path, cipher).unwrap_or_else(|e| {
-            warn!("Initialize store as default {:?}", e);
-            Default::default()
-        })
-    }
-
-    fn try_new<P: AsRef<Path>>(path: P, cipher: &Aes256GcmSiv) -> Result<Self, Error> {
-        let decrypted = load_decrypt("store", path, cipher)?;
         let store = serde_cbor::from_slice(&decrypted)?;
         Ok(store)
     }
@@ -166,7 +158,6 @@ impl StoreMeta {
         let key = GenericArray::from_slice(&key_bytes);
         let cipher = Aes256GcmSiv::new(&key);
         let cache = RawCache::new(path.as_ref(), &cipher);
-        let store = RawStore::new(path.as_ref(), &cipher);
         let path = path.as_ref().to_path_buf();
         if !path.exists() {
             std::fs::create_dir_all(&path)?;
@@ -180,7 +171,6 @@ impl StoreMeta {
 
         Ok(StoreMeta {
             cache,
-            store,
             cipher,
             secp,
             path,
@@ -219,13 +209,7 @@ impl StoreMeta {
         Ok(())
     }
 
-    fn flush_store(&self) -> Result<(), Error> {
-        self.flush_serializable("store", &self.store)?;
-        Ok(())
-    }
-
     pub fn flush(&self) -> Result<(), Error> {
-        self.flush_store()?;
         self.flush_cache()?;
         Ok(())
     }
@@ -272,28 +256,6 @@ impl StoreMeta {
         } else {
             self.cache.fee_estimates.clone()
         }
-    }
-
-    pub fn liquidex_assets(&self) -> HashSet<elements::issuance::AssetId> {
-        self.store.liquidex_assets.clone()
-    }
-
-    pub fn liquidex_assets_insert(
-        &mut self,
-        asset: elements::issuance::AssetId,
-    ) -> Result<bool, Error> {
-        let inserted = self.store.liquidex_assets.insert(asset);
-        self.flush_store()?;
-        Ok(inserted)
-    }
-
-    pub fn liquidex_assets_remove(
-        &mut self,
-        asset: &elements::issuance::AssetId,
-    ) -> Result<bool, Error> {
-        let removed = self.store.liquidex_assets.remove(asset);
-        self.flush_store()?;
-        Ok(removed)
     }
 }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -266,7 +266,6 @@ pub fn add_input(tx: &mut elements::Transaction, outpoint: elements::OutPoint) {
     let new_in = elements::TxIn {
         previous_output: outpoint,
         is_pegin: false,
-        has_issuance: false,
         script_sig: Script::default(),
         sequence: 0xffff_fffe, // nSequence is disabled, nLocktime is enabled, RBF is not signaled.
         asset_issuance: Default::default(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,33 +1,3 @@
-use elements::bitcoin::hashes::{sha256, Hash, HashEngine, Hmac, HmacEngine};
-
-/// Derive blinders as Ledger and Jade do
-// TODO: add test vectors
-pub fn derive_blinder(
-    master_blinding_key: &elements::slip77::MasterBlindingKey,
-    hash_prevouts: &elements::bitcoin::hashes::sha256d::Hash,
-    vout: u32,
-    is_asset_blinder: bool,
-) -> Result<elements::secp256k1_zkp::Tweak, elements::secp256k1_zkp::Error> {
-    let key: &[u8] = &master_blinding_key.0[..];
-    let mut engine: HmacEngine<sha256::Hash> = HmacEngine::new(key);
-    engine.input(&hash_prevouts[..]);
-    let key2 = &Hmac::from_engine(engine)[..];
-    let mut engine2: HmacEngine<sha256::Hash> = HmacEngine::new(key2);
-    let start = if is_asset_blinder { b'A' } else { b'V' };
-    let msg: [u8; 7] = [
-        start,
-        b'B',
-        b'F',
-        ((vout >> 24) & 0xff) as u8,
-        ((vout >> 16) & 0xff) as u8,
-        ((vout >> 8) & 0xff) as u8,
-        (vout & 0xff) as u8,
-    ];
-    engine2.input(&msg);
-    let blinder: elements::bitcoin::hashes::Hmac<sha256::Hash> = Hmac::from_engine(engine2).into();
-    elements::secp256k1_zkp::Tweak::from_slice(&blinder.into_inner())
-}
-
 pub fn tx_to_hex(tx: &elements::Transaction) -> String {
     hex::encode(elements::encode::serialize(tx))
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -61,9 +61,6 @@ fn dex() {
     taker.fund_btc(&mut server);
     let asset1 = taker.fund_asset(&mut server);
 
-    // asset db tests
-    taker.liquidex_assets_db_roundtrip();
-
     let mnemonic2 = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon actual".to_string();
     let mut maker = test_session::TestElectrumWallet::new(&server.electrs.electrum_url, mnemonic2);
 
@@ -75,7 +72,6 @@ fn dex() {
     assert_eq!(maker.balance(&asset2), 10_000);
 
     // asset2 10_000 <-> asset1 10_000 (no change)
-    maker.liquidex_add_asset(&asset1);
     let utxo = maker.asset_utxos(&asset2)[0].txo.outpoint;
     let proposal = maker.liquidex_make(&utxo, &asset1, 1.0);
 
@@ -89,7 +85,6 @@ fn dex() {
     assert_eq!(maker.balance(&asset2), 0);
 
     // asset1 10_000 <-> asset2 5_000 (maker creates change)
-    maker.liquidex_add_asset(&asset2);
     let utxo = maker.asset_utxos(&asset1)[0].txo.outpoint;
     let proposal = maker.liquidex_make(&utxo, &asset2, 0.5);
 
@@ -105,7 +100,6 @@ fn dex() {
     // asset2 5_000 <-> L-BTC 5_000
     let policy_asset = taker.policy_asset();
     let sats_w1_policy_before = taker.balance(&policy_asset);
-    maker.liquidex_add_asset(&policy_asset);
     let utxo = maker.asset_utxos(&asset2)[0].txo.outpoint;
     let proposal = maker.liquidex_make(&utxo, &policy_asset, 1.0);
 
@@ -168,7 +162,6 @@ fn dex() {
     assert!(balance_btc_0 > 0);
 
     // asset2 5_000 <-> asset1 10_000 (no change)
-    taker.liquidex_add_asset(&asset1);
     let utxo = taker.asset_utxos(&asset2)[0].txo.outpoint;
     let proposal = taker.liquidex_make(&utxo, &asset1, 2.0);
 
@@ -195,7 +188,6 @@ fn dex() {
     assert_eq!(balance_btc_2, balance_btc_1 - fee);
 
     // asset2 5_000 <-> L-BTC 5_000
-    taker.liquidex_add_asset(&policy_asset);
     let utxo = taker.asset_utxos(&asset2)[0].txo.outpoint;
     let proposal = taker.liquidex_make(&utxo, &policy_asset, 1.0);
 
@@ -224,7 +216,6 @@ fn dex() {
     assert_eq!(balance_btc_4, balance_btc_3 - fee);
 
     // asset2 5_000 <-> asset2 5_000
-    taker.liquidex_add_asset(&asset2);
     let utxo = taker.asset_utxos(&asset2)[0].txo.outpoint;
     let proposal = taker.liquidex_make(&utxo, &policy_asset, 1.0);
 

--- a/tests/test_session.rs
+++ b/tests/test_session.rs
@@ -771,32 +771,6 @@ impl TestElectrumWallet {
         );
     }
 
-    pub fn liquidex_assets_db_roundtrip(&self) {
-        let asset = elements::issuance::AssetId::from_slice(&[0; 32]).unwrap();
-        assert_eq!(self.electrum_wallet.liquidex_assets().unwrap().len(), 0);
-        assert!(self
-            .electrum_wallet
-            .liquidex_assets_insert(asset.clone())
-            .unwrap());
-        assert_eq!(self.electrum_wallet.liquidex_assets().unwrap().len(), 1);
-        assert!(!self
-            .electrum_wallet
-            .liquidex_assets_insert(asset.clone())
-            .unwrap());
-        assert_eq!(self.electrum_wallet.liquidex_assets().unwrap().len(), 1);
-        assert!(self.electrum_wallet.liquidex_assets_remove(&asset).unwrap());
-        assert_eq!(self.electrum_wallet.liquidex_assets().unwrap().len(), 0);
-        assert!(!self.electrum_wallet.liquidex_assets_remove(&asset).unwrap());
-        assert_eq!(self.electrum_wallet.liquidex_assets().unwrap().len(), 0);
-    }
-
-    pub fn liquidex_add_asset(&mut self, asset: &elements::issuance::AssetId) {
-        assert!(self
-            .electrum_wallet
-            .liquidex_assets_insert(asset.clone())
-            .unwrap());
-    }
-
     pub fn liquidex_make(
         &self,
         utxo: &elements::OutPoint,


### PR DESCRIPTION
This is a breaking change, removing support for LiquiDEX v0 and
adding support for LiquiDEX v1.

* update the proposal format: replace value blinding factors with
  blind value proofs and add scalar offsets.
* remove `liquidex_unblind`
* remove `liquidex_assets*` functions
* remove `RawStore`

Code will be improved once https://github.com/ElementsProject/rust-elements/pull/146 and https://github.com/ElementsProject/rust-secp256k1-zkp/pull/55 will be available from upstream.